### PR TITLE
feat: enrich Analytics tab with 5 dashboards

### DIFF
--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/di/UseCaseModule.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/di/UseCaseModule.kt
@@ -27,6 +27,7 @@ import com.ajay.seenu.expensetracker.domain.usecase.category.UpdateCategoryUseCa
 import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetExpenseByCategoryUseCase
 import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetFilteredOverallDataUseCase
 import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetFilteredTransactionsUseCase
+import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetIncomeAndExpensePerDayUseCase
 import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetRecentTransactionsUseCase
 import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetTotalTransactionPerDayByCategoryUseCase
 import com.ajay.seenu.expensetracker.domain.usecase.transaction.AddTransactionUseCase
@@ -183,6 +184,11 @@ object UseCaseModule {
     @Provides
     fun provideGetTotalTransactionPerDayByCategoryUseCase(repository: TransactionRepository): GetTotalTransactionPerDayByCategoryUseCase {
         return GetTotalTransactionPerDayByCategoryUseCase(repository)
+    }
+
+    @Provides
+    fun provideGetIncomeAndExpensePerDayUseCase(repository: TransactionRepository): GetIncomeAndExpensePerDayUseCase {
+        return GetIncomeAndExpensePerDayUseCase(repository)
     }
 
     @Provides

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/components/SlidingSwitch.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/components/SlidingSwitch.kt
@@ -59,7 +59,7 @@ fun SlidingSwitch(
     var currentValue by rememberSaveable(selectedValue) {
         mutableStateOf(selectedValue)
     }
-    var width by remember { mutableFloatStateOf(0f) }
+    var width by rememberSaveable { mutableStateOf(0f) }
     val offsetAnim by animateFloatAsState(
         targetValue = (width / values.size) * values.indexOf(currentValue),
         animationSpec = tween(500),
@@ -131,7 +131,7 @@ fun SlidingSwitch(
     var currentValue by rememberSaveable {
         mutableStateOf(selectedValue)
     }
-    var width by remember { mutableFloatStateOf(0f) }
+    var width by rememberSaveable { mutableStateOf(0f) }
     val offsetAnim by animateFloatAsState(
         targetValue = (width / values.size) * values.indexOf(currentValue),
         animationSpec = tween(animationDuration),

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/navigation/MainScreen.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/navigation/MainScreen.kt
@@ -33,7 +33,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.ajay.seenu.expensetracker.android.presentation.screeens.OverviewScreen
 import com.ajay.seenu.expensetracker.android.presentation.screeens.SettingsScreen
-import com.ajay.seenu.expensetracker.android.presentation.screeens.SimpleAnalyticsScreen
+import com.ajay.seenu.expensetracker.android.presentation.screeens.AnalyticsScreen
 import com.ajay.seenu.expensetracker.android.presentation.screeens.budget.BudgetScreen
 import com.ajay.seenu.expensetracker.android.presentation.viewmodels.BudgetViewModel
 
@@ -126,8 +126,7 @@ fun MainScreen(
                 )
             }
             composable(Screen.Analytics.route) {
-//                AnalyticsScreen(navController = navController)
-                SimpleAnalyticsScreen()
+                AnalyticsScreen(navController = navController)
             }
             composable(Screen.Settings.route) {
                 SettingsScreen(

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/AnalyticsScreen.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/AnalyticsScreen.kt
@@ -12,10 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
-import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
-import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.CardDefaults
@@ -127,25 +124,14 @@ fun AnalyticsScreen(navController: NavController, viewModel: AnalyticsViewModel 
             Spacer(modifier = Modifier.width(10.dp))
         }
     }) { paddingValues ->
-        LazyVerticalStaggeredGrid(
-            columns = StaggeredGridCells.Fixed(2),
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
             contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-            verticalItemSpacing = 12.dp,
-            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp),
+            verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp),
         ) {
-            items(
-                count = viewModel.chartOrder.size,
-                span = { index ->
-                    when (viewModel.chartOrder[index]) {
-                        Charts.INCOME_EXPENSE_TREND,
-                        Charts.TOTAL_EXPENSE_PER_DAY_BY_CATEGORY -> StaggeredGridItemSpan.FullLine
-                        else -> StaggeredGridItemSpan.SingleLane
-                    }
-                },
-            ) { index ->
+            items(viewModel.chartOrder.size) { index ->
                 val cellModifier = Modifier.fillMaxWidth()
                 when (val chartType = viewModel.chartOrder[index]) {
                     Charts.SUMMARY_KPI -> {

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/AnalyticsScreen.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/AnalyticsScreen.kt
@@ -12,10 +12,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -34,15 +39,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.ajay.seenu.expensetracker.android.R
 import com.ajay.seenu.expensetracker.android.data.FilterPreference
-import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.ExpenseByCategoryChart
+import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.BudgetHealthSection
+import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.ExpenseByCategoryDonutSection
+import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.IncomeExpenseTrendChart
+import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.SummaryKpiSection
+import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.TopSpendingCategoriesSection
 import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.TotalExpensePerDayChart
 import com.ajay.seenu.expensetracker.android.presentation.viewmodels.AnalyticsViewModel
 import com.ajay.seenu.expensetracker.android.presentation.viewmodels.Charts
@@ -83,7 +94,7 @@ fun AnalyticsScreen(navController: NavController, viewModel: AnalyticsViewModel 
         }
     }
 
-    Scaffold(topBar = {
+    Scaffold(containerColor = MaterialTheme.colorScheme.surfaceContainerLow, topBar = {
         ConstraintLayout(modifier = Modifier.fillMaxWidth()) {
             val box = createRef()
             BadgedBox(
@@ -116,15 +127,76 @@ fun AnalyticsScreen(navController: NavController, viewModel: AnalyticsViewModel 
             Spacer(modifier = Modifier.width(10.dp))
         }
     }) { paddingValues ->
-        LazyColumn(
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Fixed(2),
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues)
+                .padding(paddingValues),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+            verticalItemSpacing = 12.dp,
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(12.dp),
         ) {
-            items(viewModel.chartOrder.size) {
-                when (val chartType = viewModel.chartOrder[it]) {
+            items(
+                count = viewModel.chartOrder.size,
+                span = { index ->
+                    when (viewModel.chartOrder[index]) {
+                        Charts.INCOME_EXPENSE_TREND,
+                        Charts.TOTAL_EXPENSE_PER_DAY_BY_CATEGORY -> StaggeredGridItemSpan.FullLine
+                        else -> StaggeredGridItemSpan.SingleLane
+                    }
+                },
+            ) { index ->
+                val cellModifier = Modifier.fillMaxWidth()
+                when (val chartType = viewModel.chartOrder[index]) {
+                    Charts.SUMMARY_KPI -> {
+                        ChartContainer(cellModifier, chartType.label) {
+                            SummaryKpiSection(
+                                modifier = Modifier.fillMaxWidth(),
+                                filter = currentFilter,
+                            )
+                        }
+                    }
+
+                    Charts.EXPENSE_BY_CATEGORY_DONUT -> {
+                        ChartContainer(cellModifier, chartType.label) {
+                            ExpenseByCategoryDonutSection(
+                                modifier = Modifier.fillMaxWidth(),
+                                filter = currentFilter,
+                            )
+                        }
+                    }
+
+                    Charts.INCOME_EXPENSE_TREND -> {
+                        ChartContainer(cellModifier, chartType.label) {
+                            IncomeExpenseTrendChart(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(260.dp),
+                                filter = currentFilter,
+                            )
+                        }
+                    }
+
+                    Charts.TOP_SPENDING_CATEGORIES -> {
+                        ChartContainer(cellModifier, chartType.label) {
+                            TopSpendingCategoriesSection(
+                                modifier = Modifier.fillMaxWidth(),
+                                filter = currentFilter,
+                            )
+                        }
+                    }
+
+                    Charts.BUDGET_HEALTH -> {
+                        ChartContainer(cellModifier, chartType.label) {
+                            BudgetHealthSection(
+                                modifier = Modifier.fillMaxWidth(),
+                                filter = currentFilter,
+                            )
+                        }
+                    }
+
                     Charts.TOTAL_EXPENSE_PER_DAY_BY_CATEGORY -> {
-                        ChartContainer(Modifier, chartType.label) {
+                        ChartContainer(cellModifier, chartType.label) {
                             TotalExpensePerDayChart(
                                 Modifier
                                     .fillMaxWidth()
@@ -135,17 +207,7 @@ fun AnalyticsScreen(navController: NavController, viewModel: AnalyticsViewModel 
                         }
                     }
 
-                    Charts.EXPENSE_BY_CATEGORY -> {
-                        ChartContainer(Modifier, chartType.label) {
-                            ExpenseByCategoryChart(
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 4.dp, vertical = 2.dp)
-                                    .height(300.dp),
-                                currentFilter
-                            )
-                        }
-                    }
+                    Charts.EXPENSE_BY_CATEGORY -> Unit
                 }
             }
         }
@@ -188,14 +250,24 @@ fun AnalyticsScreen(navController: NavController, viewModel: AnalyticsViewModel 
 
 @Composable
 fun ChartContainer(modifier: Modifier = Modifier, title: String, chart: @Composable () -> Unit) {
-    Column(modifier = modifier) {
-        Text(title)
-        Spacer(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(4.dp)
-        )
-        chart()
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface,
+        ),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            chart()
+        }
     }
 }
 

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/BudgetHealthSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/BudgetHealthSection.kt
@@ -47,21 +47,26 @@ fun BudgetHealthSection(
         return
     }
 
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        StatLine("Budgeted", health.totalBudgeted.asCurrency(LocalCurrencySymbol.current))
-        StatLine("Spent", health.totalSpent.asCurrency(LocalCurrencySymbol.current))
-        val remainingColor = if (health.totalRemaining < 0.0) ChartDefaults.expenseColor else MaterialTheme.colorScheme.onSurface
-        StatLine(
-            label = "Remaining",
-            value = health.totalRemaining.asCurrency(LocalCurrencySymbol.current),
-            valueColor = remainingColor,
-        )
-        StatLine(
-            label = "Used",
-            value = "${"%.0f".format(health.overallUsedPercent)}%",
-        )
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            StatTile("Budgeted", health.totalBudgeted.asCurrency(LocalCurrencySymbol.current), Modifier.weight(1f))
+            StatTile("Spent", health.totalSpent.asCurrency(LocalCurrencySymbol.current), Modifier.weight(1f))
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
+            val remainingColor = if (health.totalRemaining < 0.0) ChartDefaults.expenseColor else MaterialTheme.colorScheme.onSurface
+            StatTile(
+                label = "Remaining",
+                value = health.totalRemaining.asCurrency(LocalCurrencySymbol.current),
+                valueColor = remainingColor,
+                modifier = Modifier.weight(1f),
+            )
+            StatTile(
+                label = "Used",
+                value = "${"%.0f".format(health.overallUsedPercent)}%",
+                modifier = Modifier.weight(1f),
+            )
+        }
 
-        Spacer(modifier = Modifier.height(2.dp))
         StatusRow(atRisk = health.atRiskCount, overBudget = health.overBudgetCount)
 
         if (health.topOffenders.isNotEmpty()) {
@@ -78,32 +83,27 @@ fun BudgetHealthSection(
 }
 
 @Composable
-private fun StatLine(
+private fun StatTile(
     label: String,
     value: String,
+    modifier: Modifier = Modifier,
     valueColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
+    Column(
+        modifier = modifier
             .clip(RoundedCornerShape(10.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
-            .padding(horizontal = 10.dp, vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .padding(horizontal = 12.dp, vertical = 10.dp)
     ) {
-        Text(
-            text = label,
-            fontSize = 12.sp,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.weight(1f),
-        )
-        Text(text = value, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = valueColor)
+        Text(text = label, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(text = value, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, color = valueColor)
     }
 }
 
 @Composable
 private fun StatusRow(atRisk: Int, overBudget: Int) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
         StatusChip(
             label = "At risk",
             count = atRisk,

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/BudgetHealthSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/BudgetHealthSection.kt
@@ -1,0 +1,210 @@
+package com.ajay.seenu.expensetracker.android.presentation.screeens.charts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ajay.seenu.expensetracker.android.presentation.common.ChartDefaults
+import com.ajay.seenu.expensetracker.android.presentation.theme.LocalCurrencySymbol
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.BudgetHealthViewModel
+import com.ajay.seenu.expensetracker.android.util.asCurrency
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.ajay.seenu.expensetracker.domain.model.budget.BudgetWithSpending
+
+@Composable
+fun BudgetHealthSection(
+    modifier: Modifier = Modifier,
+    filter: DateFilter = DateFilter.ThisMonth,
+    viewModel: BudgetHealthViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(filter) { viewModel.setFilter(filter) }
+    val health by viewModel.health.collectAsStateWithLifecycle()
+
+    if (!health.hasBudgets) {
+        EmptyBudgets(modifier.fillMaxWidth())
+        return
+    }
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        StatLine("Budgeted", health.totalBudgeted.asCurrency(LocalCurrencySymbol.current))
+        StatLine("Spent", health.totalSpent.asCurrency(LocalCurrencySymbol.current))
+        val remainingColor = if (health.totalRemaining < 0.0) ChartDefaults.expenseColor else MaterialTheme.colorScheme.onSurface
+        StatLine(
+            label = "Remaining",
+            value = health.totalRemaining.asCurrency(LocalCurrencySymbol.current),
+            valueColor = remainingColor,
+        )
+        StatLine(
+            label = "Used",
+            value = "${"%.0f".format(health.overallUsedPercent)}%",
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+        StatusRow(atRisk = health.atRiskCount, overBudget = health.overBudgetCount)
+
+        if (health.topOffenders.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = "Needs attention",
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            health.topOffenders.forEach { OffenderRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun StatLine(
+    label: String,
+    value: String,
+    valueColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(text = value, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, color = valueColor)
+    }
+}
+
+@Composable
+private fun StatusRow(atRisk: Int, overBudget: Int) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        StatusChip(
+            label = "At risk",
+            count = atRisk,
+            tint = if (atRisk > 0) Color(0xFFFFA726) else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        StatusChip(
+            label = "Over budget",
+            count = overBudget,
+            tint = if (overBudget > 0) ChartDefaults.expenseColor else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun StatusChip(label: String, count: Int, tint: Color) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .background(tint, RoundedCornerShape(4.dp))
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = "$label: $count",
+            fontSize = 13.sp,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun OffenderRow(row: BudgetWithSpending) {
+    val percentText = "${"%.0f".format(row.percentageUsed)}%"
+    val isOver = row.isOverBudget
+    val tint = if (isOver) ChartDefaults.expenseColor else Color(0xFFFFA726)
+    val symbol = if (isOver) "!" else "⚠"
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(20.dp)
+                    .background(tint.copy(alpha = 0.18f), RoundedCornerShape(10.dp)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(text = symbol, color = tint, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = row.budget.name,
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 14.sp,
+            )
+            Text(
+                text = percentText,
+                color = tint,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        val barFraction = (row.percentageUsed / 100.0).coerceIn(0.0, 1.0).toFloat()
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(barFraction)
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(tint)
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+@Composable
+private fun EmptyBudgets(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "No active budgets",
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 14.sp,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = "Set one up from the Budget tab.",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 12.sp,
+        )
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/ExpenseByCategoryDonutSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/ExpenseByCategoryDonutSection.kt
@@ -47,8 +47,6 @@ import com.ajay.seenu.expensetracker.domain.model.Category
 import com.ajay.seenu.expensetracker.domain.model.DateFilter
 import com.ajay.seenu.expensetracker.domain.model.TransactionType
 
-private const val MAX_LEGEND_ROWS = 5
-
 @Composable
 fun ExpenseByCategoryDonutSection(
     modifier: Modifier = Modifier,
@@ -89,7 +87,7 @@ fun ExpenseByCategoryDonutSection(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(160.dp),
+                        .height(220.dp),
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator()
@@ -100,7 +98,7 @@ fun ExpenseByCategoryDonutSection(
                 InsufficientDataCard(
                     Modifier
                         .fillMaxWidth()
-                        .height(160.dp)
+                        .height(220.dp)
                 )
             }
 
@@ -112,14 +110,14 @@ fun ExpenseByCategoryDonutSection(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(180.dp)
+                        .height(240.dp)
                 ) {
                     val totalLabel = chartData.sum.asCurrency(LocalCurrencySymbol.current)
                     val style = PieChartStyle(
-                        strokeWidth = 22.dp,
-                        highlightStrokeWidth = 12.dp,
+                        strokeWidth = 28.dp,
+                        highlightStrokeWidth = 16.dp,
                         textStyle = TextStyle(
-                            fontSize = 16.sp,
+                            fontSize = 20.sp,
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
                             fontWeight = FontWeight.Bold
                         )
@@ -131,7 +129,7 @@ fun ExpenseByCategoryDonutSection(
                         label = totalLabel,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .height(180.dp)
+                            .height(240.dp)
                             .padding(4.dp),
                         style = style,
                     ) { event ->
@@ -142,9 +140,9 @@ fun ExpenseByCategoryDonutSection(
                         }
                     }
                 }
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(12.dp))
                 DonutLegend(
-                    legendData = legendData.take(MAX_LEGEND_ROWS),
+                    legendData = legendData,
                     selectedCategory = selectedCategory,
                     onTapped = { selectedCategory = it },
                 )

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/ExpenseByCategoryDonutSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/ExpenseByCategoryDonutSection.kt
@@ -1,0 +1,227 @@
+package com.ajay.seenu.expensetracker.android.presentation.screeens.charts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ajay.seenu.expensetracker.android.presentation.components.SlidingSwitch
+import com.ajay.seenu.expensetracker.android.presentation.screeens.AnalyticsLegendRowData
+import com.ajay.seenu.expensetracker.android.presentation.screeens.InsufficientDataCard
+import com.ajay.seenu.expensetracker.android.presentation.state.UiState
+import com.ajay.seenu.expensetracker.android.presentation.theme.LocalCurrencySymbol
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.SimpleAnalyticsViewModel
+import com.ajay.seenu.expensetracker.android.util.asCurrency
+import com.ajay.seenu.expensetracker.android.util.getColor
+import com.ajay.seenu.expensetracker.android.util.getPlaceHolderRes
+import com.ajay.seenu.expensetracker.android.util.getStringRes
+import com.ajay.seenu.expensetracker.domain.model.Category
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.ajay.seenu.expensetracker.domain.model.TransactionType
+
+private const val MAX_LEGEND_ROWS = 5
+
+@Composable
+fun ExpenseByCategoryDonutSection(
+    modifier: Modifier = Modifier,
+    filter: DateFilter = DateFilter.ThisMonth,
+    viewModel: SimpleAnalyticsViewModel = hiltViewModel(),
+) {
+    val selectedType by viewModel.selectedType.collectAsStateWithLifecycle()
+    val state by viewModel.data.collectAsStateWithLifecycle()
+
+    LaunchedEffect(filter, selectedType) {
+        viewModel.changeType(selectedType, filter)
+    }
+
+    var selectedCategory: Category? by rememberSaveable(filter, selectedType) {
+        mutableStateOf(null)
+    }
+
+    val filterableTypes = remember {
+        TransactionType.entries.filter { it != TransactionType.TRANSFER }
+    }
+    val typeLabels = filterableTypes.map { stringResource(it.getStringRes()) }
+
+    Column(modifier = modifier) {
+        SlidingSwitch(
+            selectedValue = stringResource(selectedType.getStringRes()),
+            values = typeLabels,
+            modifier = Modifier
+                .fillMaxWidth()
+                .widthIn(max = 600.dp),
+            shape = RoundedCornerShape(12.dp),
+        ) { index, _ ->
+            viewModel.changeType(filterableTypes[index], filter)
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+
+        when (val uiState = state) {
+            UiState.Loading, UiState.Empty -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(160.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            is UiState.Failure -> {
+                InsufficientDataCard(
+                    Modifier
+                        .fillMaxWidth()
+                        .height(160.dp)
+                )
+            }
+
+            is UiState.Success -> {
+                val data = uiState.data
+                val chartData = data.chartData
+                val legendData = data.legendData
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(180.dp)
+                ) {
+                    val totalLabel = chartData.sum.asCurrency(LocalCurrencySymbol.current)
+                    val style = PieChartStyle(
+                        strokeWidth = 22.dp,
+                        highlightStrokeWidth = 12.dp,
+                        textStyle = TextStyle(
+                            fontSize = 16.sp,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
+                    val selectedEntry = chartData.entries.find { it.extras == selectedCategory }
+                    PieChart(
+                        data = chartData,
+                        selectedEntry = selectedEntry,
+                        label = totalLabel,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(180.dp)
+                            .padding(4.dp),
+                        style = style,
+                    ) { event ->
+                        selectedCategory = if (event is PieChartEvent.Selected) {
+                            event.entry.extras as Category
+                        } else {
+                            null
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                DonutLegend(
+                    legendData = legendData.take(MAX_LEGEND_ROWS),
+                    selectedCategory = selectedCategory,
+                    onTapped = { selectedCategory = it },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DonutLegend(
+    legendData: List<AnalyticsLegendRowData>,
+    selectedCategory: Category?,
+    onTapped: (Category?) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        legendData.forEach { row ->
+            val isSelected = selectedCategory != null && row.category == selectedCategory
+            DonutLegendRow(
+                data = row,
+                isSelected = isSelected,
+                modifier = Modifier.clickable {
+                    if (selectedCategory == row.category) onTapped(null) else onTapped(row.category)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DonutLegendRow(
+    data: AnalyticsLegendRowData,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(6.dp)
+    val background = if (isSelected) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(background, shape)
+            .padding(horizontal = 8.dp, vertical = 8.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(modifier = Modifier.size(10.dp).background(data.color, shape))
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = data.label,
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 14.sp,
+            )
+            val amount = stringResource(
+                data.category.type.getPlaceHolderRes(),
+                data.amount.asCurrency(LocalCurrencySymbol.current),
+            )
+            Text(
+                text = amount,
+                style = TextStyle(
+                    color = data.category.type.getColor(),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                ),
+            )
+        }
+        Spacer(modifier = Modifier.size(4.dp))
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .background(MaterialTheme.colorScheme.surfaceVariant, shape)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(data.percentage / 100f)
+                    .height(4.dp)
+                    .background(data.color, shape)
+            )
+        }
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/IncomeExpenseTrendChart.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/IncomeExpenseTrendChart.kt
@@ -1,0 +1,134 @@
+package com.ajay.seenu.expensetracker.android.presentation.screeens.charts
+
+import android.graphics.Typeface
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ajay.seenu.expensetracker.android.presentation.common.ChartDefaults
+import com.ajay.seenu.expensetracker.android.presentation.common.rememberMarker
+import com.ajay.seenu.expensetracker.android.presentation.screeens.InsufficientDataCard
+import com.ajay.seenu.expensetracker.android.presentation.screeens.Loader
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.IncomeExpenseTrendViewModel
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.patrykandpatrick.vico.compose.cartesian.CartesianChartHost
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberBottomAxis
+import com.patrykandpatrick.vico.compose.cartesian.axis.rememberStartAxis
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineSpec
+import com.patrykandpatrick.vico.compose.cartesian.rememberCartesianChart
+import com.patrykandpatrick.vico.compose.common.ProvideVicoTheme
+import com.patrykandpatrick.vico.compose.common.component.rememberShapeComponent
+import com.patrykandpatrick.vico.compose.common.component.rememberTextComponent
+import com.patrykandpatrick.vico.compose.common.of
+import com.patrykandpatrick.vico.compose.common.rememberHorizontalLegend
+import com.patrykandpatrick.vico.compose.common.rememberLegendItem
+import com.patrykandpatrick.vico.compose.common.shader.color
+import com.patrykandpatrick.vico.compose.m3.common.rememberM3VicoTheme
+import com.patrykandpatrick.vico.core.cartesian.CartesianDrawContext
+import com.patrykandpatrick.vico.core.cartesian.CartesianMeasureContext
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianValueFormatter
+import com.patrykandpatrick.vico.core.common.Dimensions
+import com.patrykandpatrick.vico.core.common.shader.DynamicShader
+import com.patrykandpatrick.vico.core.common.shape.Shape
+
+@Composable
+fun IncomeExpenseTrendChart(
+    modifier: Modifier = Modifier,
+    filter: DateFilter = DateFilter.ThisMonth,
+    viewModel: IncomeExpenseTrendViewModel = hiltViewModel(),
+) {
+    val state by viewModel.chartState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(filter) { viewModel.setFilter(filter) }
+
+    when (state) {
+        ChartState.Fetching, ChartState.Empty -> {
+            return Loader(modifier)
+        }
+        is ChartState.Failed -> {
+            return InsufficientDataCard(
+                Modifier
+                    .fillMaxWidth()
+                    .height(220.dp)
+            )
+        }
+        else -> Unit
+    }
+
+    val titleTextComponent = rememberTextComponent(color = MaterialTheme.colorScheme.onPrimaryContainer)
+    val labelTextComponent = rememberTextComponent(color = MaterialTheme.colorScheme.onPrimaryContainer)
+
+    val bottomAxis = rememberBottomAxis(
+        guideline = null,
+        title = "Date",
+        titleComponent = titleTextComponent,
+        label = labelTextComponent,
+        labelRotationDegrees = 45f,
+        valueFormatter = CartesianValueFormatter { value, chartValues, _ ->
+            val labels = chartValues.model.extraStore[viewModel.xLabelsKey]
+            val idx = value.toInt().coerceIn(0, labels.lastIndex)
+            labels[idx]
+        }
+    )
+
+    val incomeColor = ChartDefaults.incomeColor
+    val expenseColor = ChartDefaults.expenseColor
+
+    val incomeLine = rememberLineSpec(shader = DynamicShader.color(incomeColor))
+    val expenseLine = rememberLineSpec(shader = DynamicShader.color(expenseColor))
+
+    val legend = rememberHorizontalLegend<CartesianMeasureContext, CartesianDrawContext>(
+        items = listOf(
+            rememberLegendItem(
+                icon = rememberShapeComponent(Shape.Pill, color = incomeColor),
+                label = rememberTextComponent(
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    textSize = 12.sp,
+                    typeface = Typeface.MONOSPACE,
+                ),
+                labelText = "Income",
+            ),
+            rememberLegendItem(
+                icon = rememberShapeComponent(Shape.Pill, color = expenseColor),
+                label = rememberTextComponent(
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                    textSize = 12.sp,
+                    typeface = Typeface.MONOSPACE,
+                ),
+                labelText = "Expense",
+            ),
+        ),
+        iconSize = 8.dp,
+        iconPadding = 8.dp,
+        spacing = 12.dp,
+        padding = Dimensions.of(top = 8.dp, end = 8.dp),
+    )
+
+    ProvideVicoTheme(rememberM3VicoTheme(textColor = MaterialTheme.colorScheme.onPrimaryContainer)) {
+        CartesianChartHost(
+            chart = rememberCartesianChart(
+                rememberLineCartesianLayer(
+                    lines = listOf(incomeLine, expenseLine),
+                ),
+                startAxis = rememberStartAxis(
+                    title = "Amount",
+                    titleComponent = titleTextComponent,
+                ),
+                bottomAxis = bottomAxis,
+                legend = legend,
+            ),
+            modelProducer = viewModel.modelProducer,
+            modifier = modifier,
+            marker = rememberMarker(),
+            runInitialAnimation = true,
+        )
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/PieChart.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/PieChart.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -77,8 +78,8 @@ fun PieChart(
         mutableStateOf(Offset(0F, 0F))
     }
 
-    var animationTarget by remember {
-        mutableFloatStateOf(0F)
+    var animationTarget by rememberSaveable {
+        mutableStateOf(0F)
     }
 
     val animationProgress: Float by animateFloatAsState(
@@ -93,8 +94,16 @@ fun PieChart(
         animationProgress - animationTarget + 1
     }
 
-    LaunchedEffect(data) {
-        animationTarget += 1
+    val dataSignature = remember(data) {
+        data.entries.joinToString("|") { "${it.x}=${it.y}" }
+    }
+    var lastAnimatedSignature by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(dataSignature) {
+        if (lastAnimatedSignature != dataSignature) {
+            animationTarget += 1
+            lastAnimatedSignature = dataSignature
+        }
     }
 
     Canvas(modifier.pointerInput(data) {

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/SummaryKpiSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/SummaryKpiSection.kt
@@ -1,0 +1,139 @@
+package com.ajay.seenu.expensetracker.android.presentation.screeens.charts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ajay.seenu.expensetracker.android.presentation.common.ChartDefaults
+import com.ajay.seenu.expensetracker.android.presentation.theme.LocalCurrencySymbol
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.SummaryKpi
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.SummaryKpiViewModel
+import com.ajay.seenu.expensetracker.android.util.asCurrency
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+
+@Composable
+fun SummaryKpiSection(
+    modifier: Modifier = Modifier,
+    filter: DateFilter = DateFilter.ThisMonth,
+    viewModel: SummaryKpiViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(filter) { viewModel.setFilter(filter) }
+    val kpi by viewModel.kpi.collectAsStateWithLifecycle()
+    SummaryKpiGrid(kpi, modifier)
+}
+
+@Composable
+private fun SummaryKpiGrid(kpi: SummaryKpi, modifier: Modifier = Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        KpiRow(
+            label = "Income",
+            amount = kpi.income,
+            accent = ChartDefaults.incomeColor,
+        )
+        KpiRow(
+            label = "Expense",
+            amount = kpi.expense,
+            accent = ChartDefaults.expenseColor,
+        )
+        KpiRow(
+            label = "Net",
+            amount = kpi.net,
+            accent = if (kpi.net >= 0.0) ChartDefaults.incomeColor else ChartDefaults.expenseColor,
+        )
+        SavingsRateRow(rate = kpi.savingsRate)
+    }
+}
+
+@Composable
+private fun KpiRow(
+    label: String,
+    amount: Double,
+    accent: Color,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 3.dp, height = 22.dp)
+                .background(accent, RoundedCornerShape(2.dp)),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = label,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 12.sp,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = amount.asCurrency(LocalCurrencySymbol.current),
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 13.sp,
+        )
+    }
+}
+
+@Composable
+private fun SavingsRateRow(rate: Double) {
+    val accent = when {
+        rate >= 20.0 -> ChartDefaults.incomeColor
+        rate >= 0.0 -> Color(0xFFFFA726)
+        else -> ChartDefaults.expenseColor
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 3.dp, height = 22.dp)
+                .background(accent, RoundedCornerShape(2.dp)),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "Savings rate",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 12.sp,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = "${"%.1f".format(rate)}%",
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 13.sp,
+        )
+    }
+}
+

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/SummaryKpiSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/SummaryKpiSection.kt
@@ -46,94 +46,106 @@ fun SummaryKpiSection(
 
 @Composable
 private fun SummaryKpiGrid(kpi: SummaryKpi, modifier: Modifier = Modifier) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        KpiRow(
-            label = "Income",
-            amount = kpi.income,
-            accent = ChartDefaults.incomeColor,
-        )
-        KpiRow(
-            label = "Expense",
-            amount = kpi.expense,
-            accent = ChartDefaults.expenseColor,
-        )
-        KpiRow(
-            label = "Net",
-            amount = kpi.net,
-            accent = if (kpi.net >= 0.0) ChartDefaults.incomeColor else ChartDefaults.expenseColor,
-        )
-        SavingsRateRow(rate = kpi.savingsRate)
+    Column(modifier = modifier) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            KpiCard(
+                label = "Income",
+                amount = kpi.income,
+                accent = ChartDefaults.incomeColor,
+                modifier = Modifier.weight(1f),
+            )
+            KpiCard(
+                label = "Expense",
+                amount = kpi.expense,
+                accent = ChartDefaults.expenseColor,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            KpiCard(
+                label = "Net",
+                amount = kpi.net,
+                accent = if (kpi.net >= 0.0) ChartDefaults.incomeColor else ChartDefaults.expenseColor,
+                modifier = Modifier.weight(1f),
+            )
+            SavingsRateCard(
+                rate = kpi.savingsRate,
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }
 
 @Composable
-private fun KpiRow(
+private fun KpiCard(
     label: String,
     amount: Double,
     accent: Color,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
-            .padding(horizontal = 10.dp, vertical = 8.dp),
+            .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
-                .size(width = 3.dp, height = 22.dp)
+                .size(width = 4.dp, height = 32.dp)
                 .background(accent, RoundedCornerShape(2.dp)),
         )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = label,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontSize = 12.sp,
-            modifier = Modifier.weight(1f),
-        )
-        Text(
-            text = amount.asCurrency(LocalCurrencySymbol.current),
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.SemiBold,
-            fontSize = 13.sp,
-        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column {
+            Text(
+                text = label,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+            )
+            Text(
+                text = amount.asCurrency(LocalCurrencySymbol.current),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+            )
+        }
     }
 }
 
 @Composable
-private fun SavingsRateRow(rate: Double) {
+private fun SavingsRateCard(rate: Double, modifier: Modifier = Modifier) {
     val accent = when {
         rate >= 20.0 -> ChartDefaults.incomeColor
         rate >= 0.0 -> Color(0xFFFFA726)
         else -> ChartDefaults.expenseColor
     }
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.surfaceVariant)
-            .padding(horizontal = 10.dp, vertical = 8.dp),
+            .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
-                .size(width = 3.dp, height = 22.dp)
+                .size(width = 4.dp, height = 32.dp)
                 .background(accent, RoundedCornerShape(2.dp)),
         )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = "Savings rate",
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontSize = 12.sp,
-            modifier = Modifier.weight(1f),
-        )
-        Text(
-            text = "${"%.1f".format(rate)}%",
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.SemiBold,
-            fontSize = 13.sp,
-        )
+        Spacer(modifier = Modifier.width(10.dp))
+        Column {
+            Text(
+                text = "Savings rate",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+            )
+            Text(
+                text = "${"%.1f".format(rate)}%",
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+            )
+        }
     }
 }
 

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/TopSpendingCategoriesSection.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/screeens/charts/TopSpendingCategoriesSection.kt
@@ -1,0 +1,138 @@
+package com.ajay.seenu.expensetracker.android.presentation.screeens.charts
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ajay.seenu.expensetracker.android.presentation.screeens.InsufficientDataCard
+import com.ajay.seenu.expensetracker.android.presentation.theme.LocalCurrencySymbol
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.RankedCategory
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.TopCategoriesState
+import com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels.TopSpendingCategoriesViewModel
+import com.ajay.seenu.expensetracker.android.util.asCurrency
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+
+@Composable
+fun TopSpendingCategoriesSection(
+    modifier: Modifier = Modifier,
+    filter: DateFilter = DateFilter.ThisMonth,
+    viewModel: TopSpendingCategoriesViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(filter) { viewModel.setFilter(filter) }
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    when (val s = state) {
+        TopCategoriesState.Loading -> {
+            Box(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .height(160.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text("Loading…", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+        TopCategoriesState.Empty -> {
+            InsufficientDataCard(
+                modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+            )
+        }
+        is TopCategoriesState.Ready -> RankedList(s.rows, modifier)
+    }
+}
+
+@Composable
+private fun RankedList(rows: List<RankedCategory>, modifier: Modifier = Modifier) {
+    val topAmount = rows.first().amount.coerceAtLeast(1.0)
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        rows.forEach { row ->
+            CategoryRow(row, fillFraction = (row.amount / topAmount).toFloat().coerceIn(0f, 1f))
+        }
+    }
+}
+
+@Composable
+private fun CategoryRow(row: RankedCategory, fillFraction: Float) {
+    val tint = Color(row.category.color)
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .clip(CircleShape)
+                    .background(tint.copy(alpha = 0.18f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(row.category.iconRes),
+                    contentDescription = row.category.label,
+                    tint = tint,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+            Spacer(modifier = Modifier.size(10.dp))
+            Text(
+                text = row.category.label,
+                modifier = Modifier.weight(1f),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 14.sp,
+            )
+            Text(
+                text = row.amount.asCurrency(LocalCurrencySymbol.current),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+            )
+        }
+        Spacer(modifier = Modifier.size(4.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(3.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(fillFraction)
+                        .height(6.dp)
+                        .clip(RoundedCornerShape(3.dp))
+                        .background(tint)
+                )
+            }
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = "${"%.0f".format(row.percentOfTotal)}%",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+            )
+        }
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/AnalyticsViewModel.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/AnalyticsViewModel.kt
@@ -20,7 +20,14 @@ class AnalyticsViewModel @Inject constructor(
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
-    val chartOrder: List<Charts> = Charts.entries
+    val chartOrder: List<Charts> = listOf(
+        Charts.SUMMARY_KPI,
+        Charts.TOP_SPENDING_CATEGORIES,
+        Charts.EXPENSE_BY_CATEGORY_DONUT,
+        Charts.BUDGET_HEALTH,
+        Charts.INCOME_EXPENSE_TREND,
+        Charts.TOTAL_EXPENSE_PER_DAY_BY_CATEGORY,
+    )
 
     private val _currentFilter: MutableStateFlow<DateFilter> = MutableStateFlow(DateFilter.ThisMonth)
     val currentFilter: StateFlow<DateFilter> = _currentFilter.asStateFlow()
@@ -40,6 +47,11 @@ class AnalyticsViewModel @Inject constructor(
 }
 
 enum class Charts(val label: String) {
+    SUMMARY_KPI("Summary"),
+    EXPENSE_BY_CATEGORY_DONUT("Expense by Category"),
+    INCOME_EXPENSE_TREND("Income vs Expense"),
+    TOP_SPENDING_CATEGORIES("Top Spending Categories"),
+    BUDGET_HEALTH("Budget Health"),
     TOTAL_EXPENSE_PER_DAY_BY_CATEGORY("Total Expense per day By Category"),
-    EXPENSE_BY_CATEGORY("Expense by Category")
+    EXPENSE_BY_CATEGORY("Expense by Category (bars)")
 }

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/BudgetHealthViewModel.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/BudgetHealthViewModel.kt
@@ -1,0 +1,79 @@
+package com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ajay.seenu.expensetracker.data.repository.BudgetRepository
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.ajay.seenu.expensetracker.domain.model.budget.BudgetWithSpending
+import com.ajay.seenu.expensetracker.domain.usecase.DateRangeCalculatorUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class BudgetHealth(
+    val totalBudgeted: Double,
+    val totalSpent: Double,
+    val overallUsedPercent: Double,
+    val atRiskCount: Int,
+    val overBudgetCount: Int,
+    val topOffenders: List<BudgetWithSpending>,
+    val totalBudgets: Int,
+) {
+    val totalRemaining: Double get() = totalBudgeted - totalSpent
+    val hasBudgets: Boolean get() = totalBudgets > 0
+}
+
+@HiltViewModel
+class BudgetHealthViewModel @Inject constructor(
+    private val budgetRepository: BudgetRepository,
+    private val dateRangeCalculator: DateRangeCalculatorUseCase,
+) : ViewModel() {
+
+    private val _health: MutableStateFlow<BudgetHealth> = MutableStateFlow(EMPTY)
+    val health: StateFlow<BudgetHealth> = _health.asStateFlow()
+
+    private var currentFilter: DateFilter? = null
+
+    fun setFilter(filter: DateFilter) {
+        if (currentFilter == filter) return
+        currentFilter = filter
+        viewModelScope.launch {
+            val range = dateRangeCalculator(filter)
+            budgetRepository.getAllBudgetsWithSpending(range).collectLatest { budgets ->
+                _health.emit(aggregate(budgets))
+            }
+        }
+    }
+
+    private fun aggregate(budgets: List<BudgetWithSpending>): BudgetHealth {
+        if (budgets.isEmpty()) return EMPTY
+        val totalBudgeted = budgets.sumOf { it.budget.amount }
+        val totalSpent = budgets.sumOf { it.spentAmount }
+        val overall = if (totalBudgeted > 0.0) (totalSpent / totalBudgeted) * 100.0 else 0.0
+        val overBudget = budgets.count { it.isOverBudget }
+        val atRisk = budgets.count { !it.isOverBudget && it.percentageUsed >= it.budget.alertThresholdPercentage * 100.0 }
+        val offenders = budgets
+            .sortedByDescending { it.percentageUsed }
+            .take(TOP_OFFENDERS)
+            .filter { it.percentageUsed >= MIN_DISPLAY_PERCENT }
+        return BudgetHealth(
+            totalBudgeted = totalBudgeted,
+            totalSpent = totalSpent,
+            overallUsedPercent = overall,
+            atRiskCount = atRisk,
+            overBudgetCount = overBudget,
+            topOffenders = offenders,
+            totalBudgets = budgets.size,
+        )
+    }
+
+    companion object {
+        private const val TOP_OFFENDERS = 3
+        private const val MIN_DISPLAY_PERCENT = 50.0
+        private val EMPTY = BudgetHealth(0.0, 0.0, 0.0, 0, 0, emptyList(), 0)
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/IncomeExpenseTrendViewModel.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/IncomeExpenseTrendViewModel.kt
@@ -1,0 +1,92 @@
+package com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ajay.seenu.expensetracker.android.presentation.screeens.charts.ChartState
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.ajay.seenu.expensetracker.domain.usecase.DateRangeCalculatorUseCase
+import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetIncomeAndExpensePerDayUseCase
+import com.patrykandpatrick.vico.core.cartesian.data.CartesianChartModelProducer
+import com.patrykandpatrick.vico.core.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.core.common.data.ExtraStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.time.ExperimentalTime
+
+@HiltViewModel
+class IncomeExpenseTrendViewModel @Inject constructor(
+    private val getIncomeAndExpensePerDay: GetIncomeAndExpensePerDayUseCase,
+    private val dateRangeCalculator: DateRangeCalculatorUseCase,
+) : ViewModel() {
+
+    private val _chartState: MutableStateFlow<ChartState> = MutableStateFlow(ChartState.Empty)
+    val chartState: StateFlow<ChartState> = _chartState.asStateFlow()
+
+    val modelProducer: CartesianChartModelProducer = CartesianChartModelProducer.build()
+    val xLabelsKey = ExtraStore.Key<List<String>>()
+
+    private var currentFilter: DateFilter? = null
+
+    fun setFilter(filter: DateFilter) {
+        if (currentFilter == filter) return
+        currentFilter = filter
+        loadData(filter)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun loadData(filter: DateFilter) {
+        viewModelScope.launch {
+            _chartState.emit(ChartState.Fetching)
+            val result = withContext(Dispatchers.Default) {
+                val dateRange = dateRangeCalculator(filter)
+                getIncomeAndExpensePerDay(dateRange)
+            }
+
+            if (result.isEmpty()) {
+                _chartState.emit(ChartState.Failed.InSufficientData)
+                return@launch
+            }
+
+            val isMonthly = result.size > 1 &&
+                result.zipWithNext().any { (a, b) -> a.date.monthNumber != b.date.monthNumber || a.date.year != b.date.year } &&
+                result.size <= 24 &&
+                result.all { it.date.dayOfMonth == 1 }
+            val labelFormatter = SimpleDateFormat(
+                if (isMonthly) "MMM yyyy" else "MMM d",
+                Locale.ENGLISH,
+            )
+            val incomes = result.map { it.income }
+            val expenses = result.map { it.expense }
+            val labels = result.map { labelFormatter.format(it.date.toJavaDate()) }
+
+            modelProducer.tryRunTransaction {
+                lineSeries {
+                    series(incomes)
+                    series(expenses)
+                }
+                updateExtras { extraStore ->
+                    extraStore[xLabelsKey] = labels
+                }
+            }
+            _chartState.emit(ChartState.Success)
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun LocalDate.toJavaDate(): Date {
+        val instant = this.atStartOfDayIn(TimeZone.currentSystemDefault())
+        return Date(instant.toEpochMilliseconds())
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/SummaryKpiViewModel.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/SummaryKpiViewModel.kt
@@ -1,0 +1,45 @@
+package com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.ajay.seenu.expensetracker.domain.usecase.DateRangeCalculatorUseCase
+import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetFilteredOverallDataUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class SummaryKpi(
+    val income: Double,
+    val expense: Double,
+) {
+    val net: Double get() = income - expense
+    val savingsRate: Double get() = if (income > 0.0) (net / income) * 100.0 else 0.0
+}
+
+@HiltViewModel
+class SummaryKpiViewModel @Inject constructor(
+    private val getOverallData: GetFilteredOverallDataUseCase,
+    private val dateRangeCalculator: DateRangeCalculatorUseCase,
+) : ViewModel() {
+
+    private val _kpi: MutableStateFlow<SummaryKpi> = MutableStateFlow(SummaryKpi(0.0, 0.0))
+    val kpi: StateFlow<SummaryKpi> = _kpi.asStateFlow()
+
+    private var currentFilter: DateFilter? = null
+
+    fun setFilter(filter: DateFilter) {
+        if (currentFilter == filter) return
+        currentFilter = filter
+        viewModelScope.launch {
+            val dateRange = dateRangeCalculator(filter)
+            getOverallData(dateRange).collectLatest { data ->
+                _kpi.emit(SummaryKpi(income = data.income, expense = data.expense))
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/TopSpendingCategoriesViewModel.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/TopSpendingCategoriesViewModel.kt
@@ -1,0 +1,74 @@
+package com.ajay.seenu.expensetracker.android.presentation.viewmodels.chart_viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ajay.seenu.expensetracker.domain.model.Category
+import com.ajay.seenu.expensetracker.domain.model.DateFilter
+import com.ajay.seenu.expensetracker.domain.usecase.DateRangeCalculatorUseCase
+import com.ajay.seenu.expensetracker.domain.usecase.data_filter.GetExpenseByCategoryUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+data class RankedCategory(
+    val category: Category,
+    val amount: Double,
+    val percentOfTotal: Double,
+)
+
+sealed interface TopCategoriesState {
+    data object Loading : TopCategoriesState
+    data object Empty : TopCategoriesState
+    data class Ready(val rows: List<RankedCategory>) : TopCategoriesState
+}
+
+@HiltViewModel
+class TopSpendingCategoriesViewModel @Inject constructor(
+    private val getExpenseByCategory: GetExpenseByCategoryUseCase,
+    private val dateRangeCalculator: DateRangeCalculatorUseCase,
+) : ViewModel() {
+
+    private val _state: MutableStateFlow<TopCategoriesState> = MutableStateFlow(TopCategoriesState.Loading)
+    val state: StateFlow<TopCategoriesState> = _state.asStateFlow()
+
+    private var currentFilter: DateFilter? = null
+
+    fun setFilter(filter: DateFilter) {
+        if (currentFilter == filter) return
+        currentFilter = filter
+        load(filter)
+    }
+
+    private fun load(filter: DateFilter) {
+        viewModelScope.launch {
+            _state.emit(TopCategoriesState.Loading)
+            val rows = withContext(Dispatchers.Default) {
+                val dateRange = dateRangeCalculator(filter)
+                val all = getExpenseByCategory(dateRange)
+                if (all.isEmpty()) return@withContext emptyList<RankedCategory>()
+                val total = all.sumOf { it.amount }
+                all
+                    .filter { it.amount > 0.0 }
+                    .sortedByDescending { it.amount }
+                    .take(TOP_N)
+                    .map { item ->
+                        RankedCategory(
+                            category = item.category,
+                            amount = item.amount,
+                            percentOfTotal = if (total > 0.0) (item.amount / total) * 100.0 else 0.0,
+                        )
+                    }
+            }
+            _state.emit(if (rows.isEmpty()) TopCategoriesState.Empty else TopCategoriesState.Ready(rows))
+        }
+    }
+
+    companion object {
+        private const val TOP_N = 5
+    }
+}

--- a/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/TotalExpensePerDayChartViewModel.kt
+++ b/androidApp/src/main/java/com/ajay/seenu/expensetracker/android/presentation/viewmodels/chart_viewmodels/TotalExpensePerDayChartViewModel.kt
@@ -19,7 +19,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import java.util.Date
 import javax.inject.Inject
+import kotlin.time.ExperimentalTime
 
 @HiltViewModel
 class TotalExpensePerDayChartViewModel @Inject constructor(
@@ -74,11 +79,17 @@ class TotalExpensePerDayChartViewModel @Inject constructor(
                     }
                 }
                 updateExtras { extraStore ->
-                    extraStore[labelListKey] = data.map { dateFormat.format(it.date) }
+                    extraStore[labelListKey] = data.map { dateFormat.format(it.date.toJavaDate()) }
                 }
             }
             _chartState.emit(ChartState.Success)
         }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun LocalDate.toJavaDate(): Date {
+        val instant = this.atStartOfDayIn(TimeZone.currentSystemDefault())
+        return Date(instant.toEpochMilliseconds())
     }
 
     fun setFilter(filter: DateFilter) {

--- a/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/data/data_source/TransactionDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/data/data_source/TransactionDataSource.kt
@@ -6,6 +6,7 @@ import com.ajay.seenu.expensetracker.GetAllTransactionsBetweenWithDetails
 import com.ajay.seenu.expensetracker.GetAllTransactionsWithDetails
 import com.ajay.seenu.expensetracker.SearchTransactionsBetweenWithDetails
 import com.ajay.seenu.expensetracker.GetDeletedTransactionsWithDetails
+import com.ajay.seenu.expensetracker.GetIncomeAndExpensePerDayBetween
 import com.ajay.seenu.expensetracker.GetOverallDataBetween
 import com.ajay.seenu.expensetracker.GetTotalAmountByCategoryAndTypeBetween
 import com.ajay.seenu.expensetracker.GetTotalExpenseByCategoryBetween
@@ -115,6 +116,10 @@ interface TransactionDataSource {
     ): List<GetTotalTransactionPerDayByTypeBetween>
 
     fun getExpenseByCategory(startDate: Long, endDate: Long): List<GetTotalExpenseByCategoryBetween>
+    fun getIncomeAndExpensePerDay(
+        startDate: Long,
+        endDate: Long
+    ): List<GetIncomeAndExpensePerDayBetween>
     fun getTotalAmountByCategoryAndType(
         type: TransactionTypeEntity,
         startDate: Long,

--- a/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/data/data_source/local/TransactionLocalDataSource.kt
+++ b/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/data/data_source/local/TransactionLocalDataSource.kt
@@ -10,6 +10,7 @@ import com.ajay.seenu.expensetracker.GetAllTransactionsBetweenWithDetails
 import com.ajay.seenu.expensetracker.GetAllTransactionsWithDetails
 import com.ajay.seenu.expensetracker.SearchTransactionsBetweenWithDetails
 import com.ajay.seenu.expensetracker.GetDeletedTransactionsWithDetails
+import com.ajay.seenu.expensetracker.GetIncomeAndExpensePerDayBetween
 import com.ajay.seenu.expensetracker.GetOverallDataBetween
 import com.ajay.seenu.expensetracker.GetTotalAmountByCategoryAndTypeBetween
 import com.ajay.seenu.expensetracker.GetTotalExpenseByCategoryBetween
@@ -348,6 +349,13 @@ class TransactionLocalDataSource constructor(
         endDate: Long
     ): List<GetTotalExpenseByCategoryBetween> {
         return queries.getTotalExpenseByCategoryBetween(startDate, endDate).executeAsList()
+    }
+
+    override fun getIncomeAndExpensePerDay(
+        startDate: Long,
+        endDate: Long
+    ): List<GetIncomeAndExpensePerDayBetween> {
+        return queries.getIncomeAndExpensePerDayBetween(startDate, endDate).executeAsList()
     }
 
     override fun getTotalAmountByCategoryAndType(

--- a/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/data/repository/TransactionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/data/repository/TransactionRepository.kt
@@ -11,6 +11,7 @@ import com.ajay.seenu.expensetracker.data.mapper.toEntity
 import com.ajay.seenu.expensetracker.data.model.TransactionTypeEntity
 import com.ajay.seenu.expensetracker.domain.model.Account
 import com.ajay.seenu.expensetracker.domain.model.Category
+import com.ajay.seenu.expensetracker.domain.model.DailyIncomeExpense
 import com.ajay.seenu.expensetracker.domain.model.DateRange
 import com.ajay.seenu.expensetracker.domain.model.ExpensePerDay
 import com.ajay.seenu.expensetracker.domain.model.OverallData
@@ -23,6 +24,8 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -241,6 +244,22 @@ class TransactionRepository constructor(
                 dateRange.start.toEpochMillis(),
                 dateRange.end.toEpochMillis()
             )
+        }
+    }
+
+    suspend fun getIncomeAndExpensePerDay(dateRange: DateRange): List<DailyIncomeExpense> {
+        return withContext(Dispatchers.IO) {
+            val tz = TimeZone.currentSystemDefault()
+            transactionLocalDataSource.getIncomeAndExpensePerDay(
+                dateRange.start.toEpochMillis(),
+                dateRange.end.toEpochMillis()
+            ).map { row ->
+                DailyIncomeExpense(
+                    date = Instant.fromEpochMilliseconds(row.createdAt).toLocalDateTime(tz).date,
+                    income = row.income,
+                    expense = row.expense,
+                )
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/domain/model/DailyIncomeExpense.kt
+++ b/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/domain/model/DailyIncomeExpense.kt
@@ -1,0 +1,9 @@
+package com.ajay.seenu.expensetracker.domain.model
+
+import kotlinx.datetime.LocalDate
+
+data class DailyIncomeExpense(
+    val date: LocalDate,
+    val income: Double,
+    val expense: Double,
+)

--- a/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/domain/usecase/data_filter/GetIncomeAndExpensePerDayUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/ajay/seenu/expensetracker/domain/usecase/data_filter/GetIncomeAndExpensePerDayUseCase.kt
@@ -1,0 +1,40 @@
+package com.ajay.seenu.expensetracker.domain.usecase.data_filter
+
+import com.ajay.seenu.expensetracker.data.repository.TransactionRepository
+import com.ajay.seenu.expensetracker.domain.model.DailyIncomeExpense
+import com.ajay.seenu.expensetracker.domain.model.DateRange
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.daysUntil
+
+class GetIncomeAndExpensePerDayUseCase(
+    private val repository: TransactionRepository
+) {
+
+    suspend operator fun invoke(dateRange: DateRange): List<DailyIncomeExpense> {
+        val daily = repository.getIncomeAndExpensePerDay(dateRange)
+        val daysSpanned = dateRange.start.daysUntil(dateRange.end)
+        return if (daysSpanned > MONTHLY_BUCKET_THRESHOLD_DAYS) {
+            bucketByMonth(daily)
+        } else {
+            daily
+        }
+    }
+
+    private fun bucketByMonth(daily: List<DailyIncomeExpense>): List<DailyIncomeExpense> {
+        if (daily.isEmpty()) return daily
+        return daily
+            .groupBy { LocalDate(it.date.year, it.date.monthNumber, 1) }
+            .map { (monthStart, entries) ->
+                DailyIncomeExpense(
+                    date = monthStart,
+                    income = entries.sumOf { it.income },
+                    expense = entries.sumOf { it.expense },
+                )
+            }
+            .sortedBy { it.date }
+    }
+
+    companion object {
+        private const val MONTHLY_BUCKET_THRESHOLD_DAYS = 90
+    }
+}

--- a/shared/src/commonMain/sqldelight/com/ajay/seenu/expensetracker/ExpenseDatabase.sq
+++ b/shared/src/commonMain/sqldelight/com/ajay/seenu/expensetracker/ExpenseDatabase.sq
@@ -223,6 +223,19 @@ SELECT categoryId, SUM(amount) AS totalAmount FROM TransactionDetailEntity WHERE
 getTotalAmountByCategoryAndTypeBetween:
 SELECT categoryId, SUM(amount) AS total FROM TransactionDetailEntity WHERE deletedAt IS NULL AND type = :type AND createdAt >= :startUTCValue AND createdAt <= :endUTCValue GROUP BY categoryId ORDER BY categoryId ASC;
 
+getIncomeAndExpensePerDayBetween:
+SELECT
+    createdAt,
+    COALESCE(SUM(CASE WHEN type = 'INCOME' THEN amount ELSE 0 END), 0) AS income,
+    COALESCE(SUM(CASE WHEN type = 'EXPENSE' THEN amount ELSE 0 END), 0) AS expense
+FROM TransactionDetailEntity
+WHERE deletedAt IS NULL
+  AND type IN ('INCOME', 'EXPENSE')
+  AND createdAt >= :startUTCValue
+  AND createdAt <= :endUTCValue
+GROUP BY createdAt
+ORDER BY createdAt ASC;
+
 getTotalExpenseByCategoryInPeriod:
 SELECT COALESCE(SUM(amount), 0) AS totalAmount
 FROM TransactionDetailEntity


### PR DESCRIPTION
## Summary
- Enrich the Analytics tab with 5 new dashboards: Summary KPI, Expense by Category (donut), Income vs Expense trend (line), Top Spending Categories, and Budget Health. Each lives in an elevated card on a soft grayish background.
- Fix the navigation route: previously the Analytics tab loaded SimpleAnalyticsScreen with AnalyticsScreen commented out, so none of the new (or old) dashboards were actually surfaced.
- Stabilize the Expense by Category dashboard against LazyColumn dispose/recompose: SlidingSwitch.width and PieChart.animationTarget now use rememberSaveable, and the pie chart only re-animates on real data content changes.
- Also fixes a latent crash in TotalExpensePerDayChartViewModel where LocalDate was passed to SimpleDateFormat.format(). Hidden until now because the screen was unreachable.

## Layer additions
- New SQL query getIncomeAndExpensePerDayBetween plus TransactionDataSource/TransactionLocalDataSource/TransactionRepository plumbing.
- New shared use case GetIncomeAndExpensePerDayUseCase (auto-buckets monthly past 90 days) and domain model DailyIncomeExpense.
- 5 new @HiltViewModel under presentation/viewmodels/chart_viewmodels/ and 5 matching composables under presentation/screeens/charts/.

## Test plan
- [ ] Open the Analytics tab and verify all 5 new dashboards render above the existing stacked-column chart.
- [ ] Switch the date filter (This Week / This Month / This Year / Custom): data-driven dashboards refresh.
- [ ] Toggle EXPENSE/INCOME on the donut: slices, legend, and totals update.
- [ ] With no transactions in range: charts show empty state; KPI strip shows zeros.
- [ ] Slow-scroll across the Income vs Expense card: no scroll bounce/glitch.
- [ ] Scroll the donut out of view and back: pie chart should NOT re-animate; the switch should NOT slide back to EXPENSE.
- [ ] With at least one over-budget and one at-risk budget: Budget Health shows correct counts and worst offenders first.
- [ ] Verify on light and dark themes: card background adapts via surface / surfaceContainerLow.

## Notes
- The 2-column grid layout was prototyped but reverted; tablet 2-column is deferred to the dedicated tablet UI pass.
- The old Expense by Category bar chart is dropped from the UI but the composable and ViewModel are kept for future reuse.